### PR TITLE
Fix path resolving bug when using typedoc-webpack-plugin

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -44,9 +44,10 @@ export function load(host: PluginHost) {
         const faviconPath = app.options.getValue('favicon') as string;
         const workingDir = process.cwd();
         const outDir = app.options.getValue('out') || './docs';
-
-        const inputFavicon = join(workingDir, faviconPath);
-        const outputFavicon = join(workingDir, outDir, basename(faviconPath));
+        const inputFavicon = (faviconPath.indexOf(workingDir)) ?
+            join(workingDir, faviconPath) : faviconPath;
+        const outputFavicon = (outDir.indexOf(workingDir) == -1) ?
+            join(workingDir, outDir, basename(faviconPath)) : join(outDir, basename(faviconPath));
 
         copyFileSync(inputFavicon, outputFavicon);
     });

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,7 @@ export function load(host: PluginHost) {
         const faviconPath = app.options.getValue('favicon') as string;
         const workingDir = process.cwd();
         const outDir = app.options.getValue('out') || './docs';
-        const inputFavicon = (faviconPath.indexOf(workingDir)) ?
+        const inputFavicon = (faviconPath.indexOf(workingDir) == -1) ?
             join(workingDir, faviconPath) : faviconPath;
         const outputFavicon = (outDir.indexOf(workingDir) == -1) ?
             join(workingDir, outDir, basename(faviconPath)) : join(outDir, basename(faviconPath));


### PR DESCRIPTION
Webpack output specifies working directory path by default, thus checking whether working directory path is already given is necessary. 