### PR TITLE
Add option to specify a custom description

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The following arguments can be used in addition to the default [TypeDoc argument
   Specify a custom link for the top-most title.<br>
   Example: `https://parent-docs-site.com`
 
+- `--customDescription`<br>
+  Specify a custom meta description.<br>
+  Example: `A test description`
+
 - `--favicon`<br>
   Specify the name or URL of the favicon file.<br>
   Example: `public/favicon.ico`

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -66,6 +66,19 @@ export function replaceTopMostTitle(html: string, title: string): string {
 }
 
 /**
+ * Replaces the meta description
+ * @param html HTML string to replace into.
+ * @param description The new description to set.
+ */
+export function replaceDescription(html: string, description: string): string {
+    return html.replace(/(<meta name="description" content=")([^<]*)("\/>)/,
+        '$1' + // Start of meta tag
+        description.replace('"', '') + // The description (also preventing escaping the attribute)
+        '$3' // end of meta tag
+    );
+}
+
+/**
  * Replaces the top-most title link.
  * @param html HTML string to replace into.
  * @param link The new link to set.

--- a/src/main.ts
+++ b/src/main.ts
@@ -7,7 +7,8 @@ import {
     makeRelativeToRoot,
     isUrl,
     replaceTopMostTitle,
-    replaceTopMostTitleLink
+    replaceTopMostTitleLink,
+    replaceDescription
 } from './helpers';
 
 const TYPEDOC_VERSION = Application.VERSION;
@@ -22,6 +23,7 @@ const pluginOptions = (app: Application) => ({
         footerTypedocVersion: app.options.getValue('footerTypedocVersion') as boolean,
         customTitle: app.options.getValue('customTitle') as string | undefined,
         customTitleLink: app.options.getValue('customTitleLink') as string | undefined,
+        customDescription: app.options.getValue('customDescription') as string | undefined
     }),
 });
 
@@ -66,6 +68,13 @@ export function load(app: Application) {
     app.options.addDeclaration({
         name: 'customTitleLink',
         help: 'Extras Plugin: Specify a custom link for the top-most title.',
+        type: ParameterType.String,
+        defaultValue: undefined
+    });
+
+    app.options.addDeclaration({
+        name: 'customDescription',
+        help: 'Extras Plugin: Specify a custom description for the website.',
         type: ParameterType.String,
         defaultValue: undefined
     });
@@ -117,6 +126,11 @@ function onPageRendered(this: PluginOptions, page: PageEvent) {
     // Set custom title link.
     if (options.customTitleLink) {
         page.contents = replaceTopMostTitleLink(page.contents, options.customTitleLink);
+    }
+
+    // Set custom description
+    if (options.customDescription) {
+        page.contents = replaceDescription(page.contents, options.customDescription);
     }
 }
 


### PR DESCRIPTION
_Noticed this wasn't a feature yet, so I decided to quickly add this._

Adds the ability to specify a custom meta description using `customDescription`. And in order to prevent escaping of the attribute at the top (even though there isn't much of a malicious vector here), the custom description is also stripped of any `"` characters.