### PR TITLE
Expand peer dependency range for typedoc

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "typedoc"
     ],
     "peerDependencies": {
-        "typedoc": "0.27.x"
+        "typedoc": "0.27.x || 0.28.x"
     },
     "devDependencies": {
         "@types/node": "^18.15.11",


### PR DESCRIPTION
Update the peerDependencies for typedoc to support both 0.27.x and 0.28.x versions, allowing compatibility with newer releases.