### PR TITLE
Emit TypeScript declaration files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
         "forceConsistentCasingInFileNames": true,
         "skipLibCheck": true,
         "strict": true,
+        "declaration": true,
         "sourceMap": true,
         "outDir": "dist",
         "verbatimModuleSyntax": true,


### PR DESCRIPTION
## Summary
- enable TypeScript declaration output in `tsconfig.json`
- make published packages include the advertised `dist/main.d.ts` types file

## Problem
`typedoc-plugin-extras@4.0.1` advertises TypeScript declarations in `package.json`:

```json
"types": "./dist/main.d.ts"
```

The published package does not contain `dist/main.d.ts` or any other `.d.ts` files, because `tsconfig.json` does not enable declaration emit.

Clean install repro against the published package:

```sh
mkdir /tmp/typedoc-plugin-extras-ts-repro
cd /tmp/typedoc-plugin-extras-ts-repro
npm init -y >/dev/null
npm install typedoc-plugin-extras@4.0.1 typedoc@latest typescript@latest >/dev/null
printf 'import plugin from "typedoc-plugin-extras";\nexport default plugin;\n' > index.ts
printf '{"compilerOptions":{"module":"NodeNext","moduleResolution":"NodeNext","target":"ES2022","strict":true,"skipLibCheck":false},"include":["index.ts"]}\n' > tsconfig.json
npx tsc --noEmit
```

Observed:

```text
index.ts(1,20): error TS7016: Could not find a declaration file for module 'typedoc-plugin-extras'.
```

Runtime import still works, so this is isolated to the missing published type declarations.

## Validation
- `npm install --package-lock=false`
- `npm run build`
- confirmed build emits `dist/main.d.ts` and `dist/helpers.d.ts`
- `npm pack --pack-destination /Users/aliou/Desktop/MakeMoney/tmp/typedoc-plugin-extras-pack --json` includes the declaration files
- clean patched-tarball install: `npx tsc --noEmit` with `moduleResolution: "NodeNext"`, `target: "ESNext"`, `strict: true`, and `skipLibCheck: false` passed
- `npm test` passed and generated docs with `typedoc --plugin typedoc-plugin-extras ...`
- `git diff --check` passed
